### PR TITLE
Change git clone command in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ You can either clone the public repository:
 
 .. code:: python
 
-    git clone git://github.com/meghnathomas/magnets
+    git clone https://github.com/meghnathomas/MAGNets
     
 Or download the tarball:
 


### PR DESCRIPTION
GIT protocol might not work everywhere. HTTPS is guaranteed to work if the user can connect to the internet.